### PR TITLE
Adds support for sending email via flask-mail in the App Engine environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# virtualenv / pyvenv files
+.Python
+include
+lib
+man

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
   - pip install speaklater --quiet
 
 before_script:
-  - wget https://googleappengine.googlecode.com/files/google_appengine_1.8.2.zip -nv
-  - unzip -q google_appengine_1.8.2.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.17.zip -nv
+  - unzip -q google_appengine_1.9.17.zip
 
 script:
   - export PYTHONPATH=$PYTHONPATH:google_appengine

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ install:
   - pip install nose --quiet
   - pip install speaklater --quiet
 
-script: nosetests
+before_script:
+  - wget https://googleappengine.googlecode.com/files/google_appengine_1.8.2.zip -nv
+  - unzip -q google_appengine_1.8.2.zip
+
+script:
+  - export PYTHONPATH=$PYTHONPATH:google_appengine
+  - nosetests
 
 branches:
   only:

--- a/examples/appengine/README.md
+++ b/examples/appengine/README.md
@@ -1,0 +1,19 @@
+# App Engine example
+
+Here's an example app that uses Flask-Mail.
+
+Set up dependencies for the App Engine bundle:
+
+```
+pip install -t examples/appengine/lib .
+```
+
+If you get an error doing that, it may be because you're on Mac OS X using Homebrew. [Follow these instructions](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Homebrew-and-Python.md#note-on-pip-install---user) to set up a `.pydistutils.cfg` in your home directory to make this work.
+
+Run the development server locally:
+
+```
+dev_appserver.py examples/appengine
+```
+
+Visit <http://localhost:8080> to test out the app and send yourself a test email. In local debug mode this will just print logging messages to the console. In production it will send a real email.

--- a/examples/appengine/app.yaml
+++ b/examples/appengine/app.yaml
@@ -1,0 +1,17 @@
+application: your-app-id-here
+version: your-version-here
+runtime: python27
+api_version: 1
+threadsafe: true
+
+libraries:
+- name: jinja2
+  version: "2.6"
+- name: markupsafe
+  version: "0.15"
+
+handlers:
+
+- url: .*
+  script: main.app
+  login: required

--- a/examples/appengine/appengine_config.py
+++ b/examples/appengine/appengine_config.py
@@ -1,0 +1,2 @@
+import sys
+sys.path.insert(0, 'lib')

--- a/examples/appengine/main.py
+++ b/examples/appengine/main.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python2.7
+
+from google.appengine.api import users
+
+from flask import Flask
+from flask.ext.mail import Mail, Message
+
+
+class Config(object):
+    MAIL_USE_APPENGINE = True
+
+
+app = Flask(__name__)
+app.config.from_object(Config())
+
+mail = Mail(app)
+
+
+@app.route('/')
+def home():
+    me = users.get_current_user()
+    message = Message(
+        'Hi there',
+        recipients=[me.email()],
+        sender=me.email(),
+        body='This is my email body')
+    mail.send(message)
+    return 'I sent you an email!'

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -204,6 +204,7 @@ class Connection(object):
                                message.mail_options,
                                message.rcpt_options)
         elif self.mail.use_appengine:
+            print(message.as_mime_message())
             email_message = appengine_mail.EmailMessage(
                 mime_message=message.as_mime_message())
             # BCC doesn't copy through the MIME conversion because it is

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -29,16 +29,19 @@ from email.header import Header
 from email.utils import formatdate, formataddr, make_msgid, parseaddr
 from contextlib import contextmanager
 
-try:
-    from google.appengine.api import mail as appengine_mail
-except (ImportError, SyntaxError):
-    # App Engine's environment breaks with a syntax error in Python3,
-    # fails with an import error if not present.
-    appengine_mail = None
-
 from flask import current_app
 
 PY3 = sys.version_info[0] == 3
+PY27 = sys.version_info[0] == 2 and sys.version_info[1] == 7
+
+# By default, App Engine is not available. It only works for Python 2.7.
+appengine_mail = None
+
+if PY27:
+    try:
+        from google.appengine.api import mail as appengine_mail
+    except ImportError:
+        pass
 
 PY34 = PY3 and sys.version_info[1] >= 4
 

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -408,11 +408,11 @@ class Message(object):
             except UnicodeEncodeError:
                 if not PY3:
                     filename = filename.encode('utf8')
-                f.add_header('Content-Disposition', attachment.disposition,
-                             filename=('UTF8', '', filename))
-            else:
-                f.add_header('Content-Disposition', '%s;filename=%s' %
-                             (attachment.disposition, attachment.filename))
+                filename = ('UTF8', '', filename)
+
+            f.add_header('Content-Disposition',
+                         attachment.disposition,
+                         filename=filename)
 
             for key, value in attachment.headers.items():
                 f.add_header(key, value)

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -390,11 +390,11 @@ class Message(object):
             except UnicodeEncodeError:
                 if not PY3:
                     filename = filename.encode('utf8')
-                filename = ('UTF8', '', filename)
-
-            f.add_header('Content-Disposition',
-                         attachment.disposition,
-                         filename=filename)
+                f.add_header('Content-Disposition', attachment.disposition,
+                             filename=('UTF8', '', filename))
+            else:
+                f.add_header('Content-Disposition', '%s;filename=%s' %
+                             (attachment.disposition, attachment.filename))
 
             for key, value in attachment.headers.items():
                 f.add_header(key, value)

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -349,6 +349,8 @@ class Message(object):
 
     def as_mime_message(self):
         """Creates the email and returns its contents as a MIME message."""
+        ascii_attachments = current_app.extensions['mail'].ascii_attachments
+        encoding = self.charset or 'utf-8'
         attachments = self.attachments or []
 
         if len(attachments) == 0 and not self.alts:
@@ -372,7 +374,6 @@ class Message(object):
 
         msg['From'] = sanitize_address(self.sender, encoding)
         msg['To'] = ', '.join(list(set(sanitize_addresses(self.recipients, encoding))))
-
         msg['Date'] = formatdate(self.date, localtime=True)
 
         # see RFC 5322 section 3.6.4.
@@ -417,6 +418,7 @@ class Message(object):
                 f.add_header(key, value)
 
             msg.attach(f)
+
         if message_policy:
             msg.policy = message_policy
 

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -31,7 +31,9 @@ from contextlib import contextmanager
 
 try:
     from google.appengine.api import mail as appengine_mail
-except ImportError:
+except (ImportError, SyntaxError):
+    # App Engine's environment breaks with a syntax error in Python3,
+    # fails with an import error if not present.
     appengine_mail = None
 
 from flask import current_app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+Flask==0.10.1
+Jinja2==2.7.3
+MarkupSafe==0.23
+Werkzeug==0.10.1
+blinker==1.3
+itsdangerous==0.24
+mock==1.0.1
+nose==1.3.4
+speaklater==1.3
+wsgiref==0.1.2

--- a/tests.py
+++ b/tests.py
@@ -706,7 +706,7 @@ class TestConnection(TestCase):
 
 if not appengine_mail:
     # App Engine not available in this environment
-    logging.exception('Cannot run App Engine tests')
+    logging.error('Cannot run App Engine tests')
 else:
     import dev_appserver
     dev_appserver.fix_sys_path()

--- a/tests.py
+++ b/tests.py
@@ -799,10 +799,11 @@ else:
 
             self.assertEquals(1, len(sent_msg.attachments))
             filename, part = sent_msg.attachments[0]
-            self.assertIsNone(filename)
-            self.assertEqual(part.disposition, 'attachment')
-            self.assertEqual(part.content_type, "text/plain")
-            self.assertEqual(part.data, b"this is a test")
+            # When the filename isn't specified, the parameter is still
+            # set in the content-disposition header, which the email Python
+            # module needs to parse out that section as an attachment.
+            self.assertEquals('None', filename)
+            self.assertEqual(part.payload.decode(), b"this is a test")
 
         def test_send_without_sender(self):
             self.app.extensions['mail'].default_sender = None

--- a/tests.py
+++ b/tests.py
@@ -706,7 +706,7 @@ class TestConnection(TestCase):
 
 if not appengine_mail:
     # App Engine not available in this environment
-    logging.error('Cannot run App Engine tests')
+    logging.error("Cannot run App Engine tests")
 else:
     import dev_appserver
     dev_appserver.fix_sys_path()
@@ -741,7 +741,7 @@ else:
             self.assertEqual("to@example.com", sent_msg.to)
             self.assertEqual("testing", sent_msg.body.decode())
             self.assertEqual(
-                self.app.extensions['mail'].default_sender,
+                self.app.extensions["mail"].default_sender,
                 sent_msg.sender)
 
         def test_send_many(self):
@@ -755,7 +755,7 @@ else:
             self.assertEqual(len(outbox), 100)
             sent_msg = outbox[0]
             self.assertEqual(
-                self.app.extensions['mail'].default_sender,
+                self.app.extensions["mail"].default_sender,
                 sent_msg.sender)
 
         def test_bcc(self):
@@ -791,7 +791,8 @@ else:
                               recipients=["to@example.com"],
                               body="testing")
                 msg.attach(data=b"this is a test",
-                           content_type="text/plain")
+                           content_type="text/plain",
+                           filename="my_filename.txt")
                 conn.send(msg)
             outbox = self.mail_stub.get_sent_messages()
             self.assertEqual(len(outbox), 1)
@@ -799,14 +800,11 @@ else:
 
             self.assertEquals(1, len(sent_msg.attachments))
             filename, part = sent_msg.attachments[0]
-            # When the filename isn't specified, the parameter is still
-            # set in the content-disposition header, which the email Python
-            # module needs to parse out that section as an attachment.
-            self.assertEquals('None', filename)
+            self.assertEquals("my_filename.txt", filename)
             self.assertEqual(part.payload.decode(), b"this is a test")
 
         def test_send_without_sender(self):
-            self.app.extensions['mail'].default_sender = None
+            self.app.extensions["mail"].default_sender = None
             msg = Message(subject="testing", recipients=["to@example.com"], body="testing")
             self.assertRaises(AssertionError, self.mail.send, msg)
 

--- a/tests.py
+++ b/tests.py
@@ -15,7 +15,8 @@ from email.header import Header
 from email import charset
 
 from flask import Flask
-from flask_mail import Mail, Message, BadHeaderError, sanitize_address, PY3
+from flask_mail import (
+    Mail, Message, BadHeaderError, appengine_mail, sanitize_address, PY3)
 from speaklater import make_lazy_string
 
 
@@ -703,12 +704,11 @@ class TestConnection(TestCase):
                     msg.rcpt_options
                 )
 
-try:
-    import dev_appserver
-except ImportError:
+if not appengine_mail:
     # App Engine not available in this environment
     logging.exception('Cannot run App Engine tests')
 else:
+    import dev_appserver
     dev_appserver.fix_sys_path()
     from google.appengine.ext import testbed
 

--- a/tests.py
+++ b/tests.py
@@ -3,12 +3,13 @@
 from __future__ import with_statement
 
 import base64
-import email
-import unittest
-import time
-import re
-import mock
 from contextlib import contextmanager
+import email
+import logging
+import mock
+import re
+import time
+import unittest
 
 from email.header import Header
 from email import charset
@@ -701,3 +702,115 @@ class TestConnection(TestCase):
                     msg.mail_options,
                     msg.rcpt_options
                 )
+
+try:
+    import dev_appserver
+except ImportError:
+    # App Engine not available in this environment
+    logging.exception('Cannot run App Engine tests')
+else:
+    dev_appserver.fix_sys_path()
+    from google.appengine.ext import testbed
+
+
+    class TestAppEngine(TestCase):
+
+        MAIL_USE_APPENGINE = True
+
+        def setUp(self):
+            super(TestAppEngine, self).setUp()
+            self.testbed = testbed.Testbed()
+            self.testbed.activate()
+            self.testbed.init_mail_stub()
+            self.mail_stub = self.testbed.get_stub(testbed.MAIL_SERVICE_NAME)
+
+        def tearDown(self):
+            super(TestAppEngine, self).tearDown()
+            self.testbed.deactivate()
+
+        def test_send_single(self):
+            with self.mail.connect() as conn:
+                msg = Message(subject="testing",
+                              recipients=["to@example.com"],
+                              body="testing")
+                conn.send(msg)
+            outbox = self.mail_stub.get_sent_messages()
+            self.assertEqual(len(outbox), 1)
+            sent_msg = outbox[0]
+            self.assertEqual("testing", sent_msg.subject)
+            self.assertEqual("to@example.com", sent_msg.to)
+            self.assertEqual("testing", sent_msg.body.decode())
+            self.assertEqual(
+                self.app.extensions['mail'].default_sender,
+                sent_msg.sender)
+
+        def test_send_many(self):
+            with self.mail.connect() as conn:
+                for i in range(100):
+                    msg = Message(subject="testing",
+                                  recipients=["to@example.com"],
+                                  body="testing")
+                    conn.send(msg)
+            outbox = self.mail_stub.get_sent_messages()
+            self.assertEqual(len(outbox), 100)
+            sent_msg = outbox[0]
+            self.assertEqual(
+                self.app.extensions['mail'].default_sender,
+                sent_msg.sender)
+
+        def test_bcc(self):
+            with self.mail.connect() as conn:
+                msg = Message(sender="from@example.com",
+                              subject="testing",
+                              recipients=["to@example.com"],
+                              body="testing",
+                              bcc=["tosomeoneelse@example.com"])
+                conn.send(msg)
+            outbox = self.mail_stub.get_sent_messages()
+            self.assertEqual(len(outbox), 1)
+            sent_msg = outbox[0]
+            self.assertEquals("tosomeoneelse@example.com", sent_msg.bcc)
+            self.assertEquals("to@example.com", sent_msg.to)
+
+        def test_cc(self):
+            with self.mail.connect() as conn:
+                msg = Message(sender="from@example.com",
+                              subject="testing",
+                              recipients=["to@example.com"],
+                              body="testing",
+                              cc=["tosomeoneelse@example.com"])
+                conn.send(msg)
+            outbox = self.mail_stub.get_sent_messages()
+            self.assertEqual(len(outbox), 1)
+            sent_msg = outbox[0]
+            self.assertIn("tosomeoneelse@example.com", sent_msg.cc)
+
+        def test_attach(self):
+            with self.mail.connect() as conn:
+                msg = Message(subject="testing",
+                              recipients=["to@example.com"],
+                              body="testing")
+                msg.attach(data=b"this is a test",
+                           content_type="text/plain")
+                conn.send(msg)
+            outbox = self.mail_stub.get_sent_messages()
+            self.assertEqual(len(outbox), 1)
+            sent_msg = outbox[0]
+
+            self.assertEquals(1, len(sent_msg.attachments))
+            filename, part = sent_msg.attachments[0]
+            self.assertIsNone(filename)
+            self.assertEqual(part.disposition, 'attachment')
+            self.assertEqual(part.content_type, "text/plain")
+            self.assertEqual(part.data, b"this is a test")
+
+        def test_send_without_sender(self):
+            self.app.extensions['mail'].default_sender = None
+            msg = Message(subject="testing", recipients=["to@example.com"], body="testing")
+            self.assertRaises(AssertionError, self.mail.send, msg)
+
+        def test_send_without_recipients(self):
+            msg = Message(subject="testing",
+                          recipients=[],
+                          body="testing")
+            self.assertRaises(AssertionError, self.mail.send, msg)


### PR DESCRIPTION
Travis build is working. This helps with #21. Tested in App Engine production and works as expected for my use-cases.