### PR TITLE
Allow custom media subtypes

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -337,6 +337,7 @@ class TestMessage(TestCase):
 
         self.assertEqual(html_text, msg.html)
         self.assertIn('Content-Type: multipart/alternative', msg.as_string())
+        self.assertIn('Content-Type: text/html', msg.as_string())
 
     def test_json_message(self):
         json_text = '{"msg": "Hello World!}'
@@ -361,6 +362,8 @@ class TestMessage(TestCase):
 
         self.assertEqual(html_text, msg.html)
         self.assertIn('Content-Type: multipart/alternative', msg.as_string())
+        self.assertIn('Content-Type: text/html', msg.as_string())
+        self.assertIn('Content-Type: text/plain', msg.as_string())
 
         parsed = email.message_from_string(msg.as_string())
         self.assertEqual(len(parsed.get_payload()), 2)
@@ -546,6 +549,22 @@ class TestMessage(TestCase):
         msg.body = "normal ascii text"
         self.mail.send(msg)
         self.assertNotIn('Subject:', msg.as_string())
+
+    def test_custom_subtype_without_attachment(self):
+        msg = Message(sender="from@example.com",
+                      subject="testing",
+                      recipients=["to@example.com"],
+                      subtype="html")
+        self.assertIn('Content-Type: text/html', msg.as_string())
+
+    def test_custom_subtype_with_attachment(self):
+        msg = Message(sender="from@example.com",
+                      subject="testing",
+                      recipients=["to@example.com"],
+                      subtype="related")
+        msg.attach(data=b"this is a test",
+                   content_type="text/plain")
+        self.assertIn('Content-Type: multipart/related', msg.as_string())
 
 class TestMail(TestCase):
 


### PR DESCRIPTION
Hi.

I've added Message constructor argument to override default MIME subtype name (mixed for multipart, plain for text).

multipart/mixed subtype caused problems in some email clients when I tried to inline images using CIDs. As this [RFC](https://tools.ietf.org/html/rfc2387) states CIDs are supposed to work if message content type is multipart/related which tells the client to assume that some parts are related to others. Otherwise all parts are assumed to be self contained and CID link may not work.

Thanks!