### PR TITLE
Ensure name/email of recipients is a tuple or string

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -125,6 +125,17 @@ def sanitize_addresses(addresses, encoding='utf-8'):
     return map(lambda e: sanitize_address(e, encoding), addresses)
 
 
+def fix_recipients_list(recipients):
+    fixed_recipients = []
+    for recipient in recipients:
+        if not isinstance(recipient, string_types):
+            # Ensure that the name/email values are a tuple and not a list
+            fixed_recipients.append(tuple(recipient))
+        else:
+            fixed_recipients.append(recipient)
+    return fixed_recipients
+
+
 def _has_newline(line):
     """Used by has_bad_header to check for \\r or \\n"""
     if line and ('\r' in line or '\n' in line):
@@ -293,6 +304,30 @@ class Message(object):
         self.mail_options = mail_options or []
         self.rcpt_options = rcpt_options or []
         self.attachments = attachments or []
+
+    @property
+    def recipients(self):
+        return self._recipients
+
+    @recipients.setter
+    def recipients(self, recipients):
+        self._recipients = fix_recipients_list(recipients)
+
+    @property
+    def cc(self):
+        return self._cc
+
+    @cc.setter
+    def cc(self, recipients):
+        self._cc = fix_recipients_list(recipients)
+
+    @property
+    def bcc(self):
+        return self._bcc
+
+    @bcc.setter
+    def bcc(self, recipients):
+        self._bcc = fix_recipients_list(recipients)
 
     @property
     def send_to(self):

--- a/tests.py
+++ b/tests.py
@@ -14,7 +14,8 @@ from email.header import Header
 from email import charset
 
 from flask import Flask
-from flask_mail import Mail, Message, BadHeaderError, sanitize_address, PY3
+from flask_mail import Mail, Message, BadHeaderError, sanitize_address, PY3, \
+    fix_recipients_list
 from speaklater import make_lazy_string
 
 
@@ -99,6 +100,11 @@ class TestMessage(TestCase):
         msg2 = Message(subject="subject")
         msg2.add_recipient("somebody@here.com")
         self.assertEqual(len(msg2.recipients), 1)
+
+    def test_fix_recipients_list(self):
+        msg = Message(subject="test")
+        msg.recipients = [["Test", "to@example.com"]]
+        assert msg.recipients[0] == ("Test", "to@example.com")
 
     def test_esmtp_options_properly_initialized(self):
         msg = Message(subject="subject")


### PR DESCRIPTION
If the tuples of recipient info get converted to lists somehow, the `send_to` property throws an error because lists are not hashable.

This can happen when the arguments for an email message are sent through celery using the json serializer.

Currently, the following code fill cause this error when trying to send the message:

``` python
msg = Message(subject='test')
msg.recipients = [
    ['Test User', 'test@example.com']
]
```
