### PR TITLE
Update flask_mail.py

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -564,7 +564,7 @@ class Mail(_MailMixin):
             config.get('MAIL_USE_TLS', False),
             config.get('MAIL_USE_SSL', False),
             config.get('MAIL_DEFAULT_SENDER'),
-            int(config.get('MAIL_DEBUG', debug)),
+            config.get('MAIL_DEBUG', debug),
             config.get('MAIL_MAX_EMAILS'),
             config.get('MAIL_SUPPRESS_SEND', testing),
             config.get('MAIL_ASCII_ATTACHMENTS', False)


### PR DESCRIPTION
Fix exception: "ValueError: invalid literal for int() with base 10: 'True'".