### PR TITLE
Generate A Universal Wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ build-dir  = docs/_build
 
 [upload_sphinx]
 upload-dir = docs/_build/html
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
I can't see anything this repo which would restrict from having a universal py2/py3 wheel. 