### PR TITLE
Sending EHLO in configure host

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -156,7 +156,8 @@ class Connection(object):
             host = smtplib.SMTP_SSL(self.mail.server, self.mail.port)
         else:
             host = smtplib.SMTP(self.mail.server, self.mail.port)
-
+        
+        host.ehlo_or_helo_if_needed()
         host.set_debuglevel(int(self.mail.debug))
 
         if self.mail.use_tls:


### PR DESCRIPTION
Fixing #154 

I don't know if this is working with other mail server, maybe should be put inside of a `try catch` block.  Would be glad if others would try it.